### PR TITLE
feat: introduce new `escapeMultilineStrings` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ logger.info("Hello world")
 | `convertToSnakeCase`     | `boolean`          | `false`         | Convert log field names to snake case.                                                                                                                        |
 | `flattenNestedObjects`   | `boolean`          | `false`         | Flatten nested metadata (e.g. `{ error: { type: "Error", message: "Something went wrong" } }` becomes `error_type=Error error_message="Something went wrong"` |
 | `flattenNestedSeparator` | `string`           | `"_"`           | The character that is used to merge keys when `flattenNestedObjects` is enabled.                                                                              |
+| `escapeMultilineStrings` | `boolean`           | `false`           | Escape multi-line strings in the log output, including deeply nested values                                                                              |
 | `destination`            | `string \| number` | `1`             | The destination where the transport will write to. By default, it logs to stdout but you can also provide a file name.                                        |
 
 
@@ -124,6 +125,7 @@ Options:
   --flatten-separator <string>  the separator used when flattening nested metadata (default: ".")
   --custom-levels, -x <string>  the levels associated to their labels in the format "10:trace,20:debug" (default: "10:trace,20:debug,30:info,40:warn,50:error,60:fatal")
   --time-format <string>        the time format to use if time formatting is enabled (default: "isoDateTime")
+  --escape-multiline-strings    escape multi-line strings in the log output, including deeply nested values (default: false)
   -h, --help                    display help for command
 ```
 
@@ -141,12 +143,9 @@ node process-that-emits-logs.js | pino-logfmt
 | `--time-format`         | `string`  | `"isoDateTime"` | A time format compatible with `dateformat`' formats.                                                                                                          |
 | `--time-key`            | `string`  | `"time"`        | The name of the key that holds the log timestamp.                                                                                                             |
 | `--snake-case`          | `boolean` | `false`         | Convert log field names to snake case.                                                                                                                        |
+| `--escape-multiline-strings`          | `boolean` | `false`         | Escape multi-line strings in the log output, including deeply nested values                                               |
 | `--flatten-nested`      | `boolean` | `false`         | Flatten nested metadata (e.g. `{ error: { type: "Error", message: "Something went wrong" } }` becomes `error_type=Error error_message="Something went wrong"` |
 | `--flatten-separator`   | `string`  | `"_"`           | The character that is used to merge keys when `flattenNestedObjects` is enabled.                                                                              |
-
-## Known issues
-
-- Stack traces (and others multi-line strings) are not escaped
 
 ## Contributing
 

--- a/src/bin.d.ts
+++ b/src/bin.d.ts
@@ -8,4 +8,5 @@ export type ProgramOptions = {
   flattenSeparator?: string
   customLevels?: string
   timeFormat?: string
+  escapeMultilineStrings?: boolean
 }

--- a/src/bin.js
+++ b/src/bin.js
@@ -24,6 +24,7 @@ function cli () {
     .option('--flatten-separator <string>', 'the separator used when flattening nested metadata', '.')
     .option('--custom-levels, -x <string>', 'the levels associated to their labels in the format "10:trace,20:debug"', serialize(baseLevelToLabel))
     .option('--time-format <string>', 'the time format to use if time formatting is enabled', 'isoDateTime')
+    .option('--escape-multiline-strings', 'escape multi-line strings in the log output, including deeply nested values', false)
     .action(action)
     .parseAsync(process.argv)
     .catch(console.error)
@@ -42,7 +43,8 @@ async function action (opts) {
     snakeCase: convertToSnakeCase,
     flattenNested: flattenNestedObjects,
     customLevels: serializedCustomLevels,
-    timeFormat
+    timeFormat,
+    escapeMultilineStrings
   } = opts
 
   const customLevels = serializedCustomLevels !== undefined
@@ -57,7 +59,8 @@ async function action (opts) {
     convertToSnakeCase,
     flattenNestedObjects,
     customLevels,
-    timeFormat
+    timeFormat,
+    escapeMultilineStrings
   })
 
   pump(process.stdin, transport)

--- a/tests/transport.spec.js
+++ b/tests/transport.spec.js
@@ -46,6 +46,52 @@ it('should be able to output logfmt formatted logs', async function () {
   ])
 })
 
+it('doesn\'t automatically escape multi-line strings', async function () {
+  // Given
+  const transport = await logfmtTransport({
+    sync: true,
+    destination: logFile
+  })
+
+  const logger = pino({
+    timestamp: false,
+    base: {}
+  }, transport)
+
+  // When
+  logger.info('foo\nbar')
+
+  // Then
+  expect(await loadLog(logFile)).to.deep.equal([
+    'level=30 msg=foo',
+    'bar',
+    ''
+  ])
+})
+
+it('escapes multi-line strings when escapeMultilineStrings is Enabled', async function () {
+  // Given
+  const transport = await logfmtTransport({
+    sync: true,
+    destination: logFile,
+    escapeMultilineStrings: true
+  })
+
+  const logger = pino({
+    timestamp: false,
+    base: {}
+  }, transport)
+
+  // When
+  logger.info('foo\nbar')
+
+  // Then
+  expect(await loadLog(logFile)).to.deep.equal([
+    'level=30 msg="foo\\\\nbar"',
+    ''
+  ])
+})
+
 it('should be able to include the level label', async function () {
   // Given
   const transport = await logfmtTransport({

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -86,6 +86,13 @@ export type LogFmtTransportOptions = {
   flattenNestedSeparator?: string
 
   /**
+   * Escape multi-line strings in the log output, including deeply nested values
+   *
+   * @default {false}
+   */
+  escapeMultilineStrings?: boolean
+
+  /**
    * Override the default level mapping.
    * Here is the default mapping:
    * ```


### PR DESCRIPTION
This adds a new `escapeMultilineStrings` option, defaulting to `false`, which recursively escapes multi-line strings in the log output.

Fixes https://github.com/botflux/pino-logfmt/issues/1.